### PR TITLE
Add dividers and pagination to learning journal

### DIFF
--- a/graphql/queries/getLearningJournals.ts
+++ b/graphql/queries/getLearningJournals.ts
@@ -1,0 +1,24 @@
+import { gql } from 'graphql-request'
+
+import { graphQLClient } from 'config/graphQLClient'
+import { LearningJournal } from 'graphql/schema'
+
+const GET_LEARNING_JOURNALS_QUERY = gql`
+  query GetLearningJournals {
+    learningJournals(orderBy: date_DESC) {
+      id
+      work
+      date
+      curiosity
+      programming
+    }
+  }
+`
+
+export async function getLearningJournals () {
+  const { learningJournals } = await graphQLClient.request(
+    GET_LEARNING_JOURNALS_QUERY
+  )
+
+  return learningJournals as Array<LearningJournal>
+}

--- a/hooks/usePagination/index.ts
+++ b/hooks/usePagination/index.ts
@@ -28,7 +28,7 @@ export function usePagination<Timeline> ({
 
   const offset = page * itemsPerPage
   const data = (list ?? []).slice(0, offset)
-  const hasMoreItems = Boolean(list[offset - 1])
+  const hasMoreItems = offset < list.length
 
   const handlePagination = () => {
     if (!hasMoreItems) {

--- a/pages/learning-journal.tsx
+++ b/pages/learning-journal.tsx
@@ -51,89 +51,91 @@ export default function LearningJournal ({
 
         <List width='full' paddingTop={5} spacing={6}>
           {
-          (formatLearningJournals ?? []).map(({
-            id,
-            date,
-            work,
-            curiosity,
-            programming
-          }) => {
-            const shouldShowWorkEntries = (work ?? []).length > 0
-            const shouldShowCuriosityEntries = (curiosity ?? []).length > 0
-            const shouldShowProgrammingEntries = (programming ?? []).length > 0
+            (formatLearningJournals ?? []).map(({
+              id,
+              date,
+              work,
+              curiosity,
+              programming
+            }, index) => {
+              const shouldShowWorkEntries = (work ?? []).length > 0
+              const shouldShowCuriosityEntries = (curiosity ?? []).length > 0
+              const shouldShowProgrammingEntries = (programming ?? []).length > 0
 
-            return (
-              <VStack
-                as='li'
-                key={id}
-                width='full'
-                spacing={5}
-                alignItems='flex-start'
-              >
-                <Text
-                  as='h3'
-                  bgClip='text'
-                  fontSize={22}
-                  fontWeight='bold'
-                  bgGradient='linear(to-r, green.400, green.500, blue.100)'
+              return (
+                <VStack
+                  as='li'
+                  key={id}
+                  width='full'
+                  spacing={5}
+                  alignItems='flex-start'
+                  paddingTop={5}
+                  borderTopWidth={1}
                 >
-                  {date}
-                </Text>
+                  <Text
+                    as='h3'
+                    bgClip='text'
+                    fontSize={22}
+                    fontWeight='bold'
+                    bgGradient='linear(to-r, green.400, green.500, blue.100)'
+                  >
+                    {date}
+                  </Text>
 
-                {
-                  shouldShowWorkEntries
-                    ? (
-                      <>
-                        <Heading size='xs'>Work</Heading>
-                        <UnorderedList paddingLeft={5}>
-                          {
-                            work.map(text => (
-                              <ListItem key={text}>{text}</ListItem>
-                            ))
-                          }
-                        </UnorderedList>
-                      </>
-                      )
-                    : null
-                }
+                  {
+                    shouldShowWorkEntries
+                      ? (
+                        <>
+                          <Heading size='xs'>Work</Heading>
+                          <UnorderedList paddingLeft={5}>
+                            {
+                              work.map(text => (
+                                <ListItem key={text}>{text}</ListItem>
+                              ))
+                            }
+                          </UnorderedList>
+                        </>
+                        )
+                      : null
+                  }
 
-                {
-                  shouldShowProgrammingEntries
-                    ? (
-                      <>
-                        <Heading size='xs'>Programming</Heading>
-                        <UnorderedList paddingLeft={5}>
-                          {
-                            programming.map(text => (
-                              <ListItem key={text}>{text}</ListItem>
-                            ))
-                          }
-                        </UnorderedList>
-                      </>
-                      )
-                    : null
-                }
+                  {
+                    shouldShowProgrammingEntries
+                      ? (
+                        <>
+                          <Heading size='xs'>Programming</Heading>
+                          <UnorderedList paddingLeft={5}>
+                            {
+                              programming.map(text => (
+                                <ListItem key={text}>{text}</ListItem>
+                              ))
+                            }
+                          </UnorderedList>
+                        </>
+                        )
+                      : null
+                  }
 
-                {
-                  shouldShowCuriosityEntries
-                    ? (
-                      <>
-                        <Heading size='xs'>Curiosity</Heading>
-                        <UnorderedList paddingLeft={5}>
-                          {
-                            curiosity.map(text => (
-                              <ListItem key={text}>{text}</ListItem>
-                            ))
-                          }
-                        </UnorderedList>
-                      </>
-                      )
-                    : null
-                }
-              </VStack>
-            )
-          })
-        }
+                  {
+                    shouldShowCuriosityEntries
+                      ? (
+                        <>
+                          <Heading size='xs'>Curiosity</Heading>
+                          <UnorderedList paddingLeft={5}>
+                            {
+                              curiosity.map(text => (
+                                <ListItem key={text}>{text}</ListItem>
+                              ))
+                            }
+                          </UnorderedList>
+                        </>
+                        )
+                      : null
+                  }
+                </VStack>
+              )
+            })
+          }
         </List>
       </VStack>
     </ChakraProvider>

--- a/pages/learning-journal.tsx
+++ b/pages/learning-journal.tsx
@@ -57,7 +57,7 @@ export default function LearningJournal ({
               work,
               curiosity,
               programming
-            }, index) => {
+            }) => {
               const shouldShowWorkEntries = (work ?? []).length > 0
               const shouldShowCuriosityEntries = (curiosity ?? []).length > 0
               const shouldShowProgrammingEntries = (programming ?? []).length > 0
@@ -72,15 +72,18 @@ export default function LearningJournal ({
                   paddingTop={5}
                   borderTopWidth={1}
                 >
-                  <Text
-                    as='h3'
-                    bgClip='text'
-                    fontSize={22}
-                    fontWeight='bold'
-                    bgGradient='linear(to-r, green.400, green.500, blue.100)'
-                  >
-                    {date}
-                  </Text>
+                  <a href={`#${date}`}>
+                    <Text
+                      as='h3'
+                      id={date}
+                      bgClip='text'
+                      fontSize={22}
+                      fontWeight='bold'
+                      bgGradient='linear(to-r, green.400, green.500, blue.100)'
+                    >
+                      {date}
+                    </Text>
+                  </a>
 
                   {
                     shouldShowWorkEntries

--- a/pages/learning-journal.tsx
+++ b/pages/learning-journal.tsx
@@ -3,7 +3,7 @@ import { List, ListItem, Text, UnorderedList, VStack } from '@chakra-ui/react'
 
 import { Heading } from 'components/Base/Heading'
 import { Paragraph } from 'components/Base/Paragraph'
-import { getLearningJournals } from 'graphql/queries/getLearningJournal'
+import { getLearningJournals } from 'graphql/queries/getLearningJournals'
 import { ChakraProvider } from 'providers/ChakraProvider'
 
 export async function getServerSideProps ({ req }) {


### PR DESCRIPTION
After adding more data to the learning journal, I decided to add dividers between each list item, because it's easier to see the difference between each day. 

I also added pagination in order to not show all the days directly.

## Implementation Styles

![image](https://user-images.githubusercontent.com/48022589/106362809-a0dfb800-6303-11eb-9b6b-dea5b0b56eb3.png)
![chrome-capture](https://user-images.githubusercontent.com/48022589/106362824-b48b1e80-6303-11eb-9ea8-b59370985061.gif)
