### PR TITLE
Use CMS to manage content from "About me" page

### DIFF
--- a/components/ImageWithCaptions/index.tsx
+++ b/components/ImageWithCaptions/index.tsx
@@ -3,32 +3,31 @@ import { Text, Stack } from '@chakra-ui/react'
 
 import { Heading } from 'components/Base/Heading'
 
-import { PlaceImageProps } from './types'
+import { ImageWithCaptionsProps } from './types'
 
-export function PlaceImage ({
-  name,
-  endYear,
+export function ImageWithCaptions ({
   imageSrc,
-  startYear,
+  subCaption,
+  mainCaption,
   ...rest
-}: PlaceImageProps) {
+}: ImageWithCaptionsProps) {
   return (
     <Stack direction='column' spacing={4} {...rest}>
       <Image
         src={imageSrc}
-        alt={`Picture of ${name} city`}
-        quality={100}
+        alt={mainCaption}
         width={734}
         height={300}
+        quality={100}
         className='next-image'
       />
 
       <Stack spacing={0.5} direction='column'>
         <Heading size='xs' as='strong'>
-          {name}
+          {mainCaption}
         </Heading>
         <Text as='small' color='gray.300'>
-          {startYear} - {endYear ?? 'Present'}
+          {subCaption}
         </Text>
       </Stack>
     </Stack>

--- a/components/ImageWithCaptions/types.ts
+++ b/components/ImageWithCaptions/types.ts
@@ -1,0 +1,7 @@
+import { StackProps } from '@chakra-ui/react'
+
+export type ImageWithCaptionsProps = StackProps & {
+  imageSrc: string;
+  subCaption: string;
+  mainCaption: string;
+}

--- a/components/PlaceImage/types.ts
+++ b/components/PlaceImage/types.ts
@@ -1,8 +1,0 @@
-import { StackProps } from '@chakra-ui/react'
-
-export type PlaceImageProps = StackProps & {
-  name: string;
-  endYear?: number;
-  imageSrc: string;
-  startYear: number;
-}

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -9,6 +9,15 @@ const GET_ABOUT_ME_PAGE_QUERY = gql`
       sections {
         id
         title
+        images(orderBy: createdAt_DESC) {
+          id
+          subCaption
+          mainCaption
+          asset {
+            id
+            url
+          }
+        }
       }
     }
   }

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -4,7 +4,7 @@ import { graphQLClient } from 'config/graphQLClient'
 import { AboutMePage } from 'graphql/schema'
 
 const GET_ABOUT_ME_PAGE_QUERY = gql`
-  query getAboutMePageSections($id: ID!){
+  query getAboutMePage($id: ID!){
     aboutMePage(where: { id: $id }){
       sections {
         id
@@ -27,9 +27,9 @@ const GET_ABOUT_ME_PAGE_QUERY = gql`
 `
 
 /**
- * Since "aboutMePage" is a contextual model, there should be
- * only one content entry for it, which at the moment relies on this ID
- * @see {@link https://graphcms.com/academy/what-is-content-modeling} for more info regarding contextual models
+ * Since "aboutMePage" is a subject model, there should be only one content
+ * entry for it, which at the moment relies on this ID
+ * @see {@link https://graphcms.com/academy/what-is-content-modeling} for more info regarding subject models
  */
 const pageIDFromCMS = 'cl04asq370z7o0ewwt2726r7t'
 

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -1,0 +1,29 @@
+import { gql } from 'graphql-request'
+
+import { graphQLClient } from 'config/graphQLClient'
+import { AboutMePage } from 'graphql/schema'
+
+const GET_ABOUT_ME_PAGE_QUERY = gql`
+  query getAboutMePageSections($id: ID!){
+    aboutMePage(where: { id: $id }){
+      sections {
+        title
+      }
+    }
+  }
+`
+
+/**
+ * Since "aboutMePage" is a contextual model, there should be
+ * only one content entry for it, which at the moment relies on this ID
+ */
+const pageIDFromCMS = 'cl04asq370z7o0ewwt2726r7t'
+
+export async function getAboutMePage () {
+  const { aboutMePage } = await graphQLClient.request(
+    GET_ABOUT_ME_PAGE_QUERY,
+    { id: pageIDFromCMS }
+  )
+
+  return aboutMePage as AboutMePage
+}

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -9,6 +9,9 @@ const GET_ABOUT_ME_PAGE_QUERY = gql`
       sections {
         id
         title
+        description {
+          raw
+        }
         images(orderBy: createdAt_DESC) {
           id
           subCaption

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -29,6 +29,7 @@ const GET_ABOUT_ME_PAGE_QUERY = gql`
 /**
  * Since "aboutMePage" is a contextual model, there should be
  * only one content entry for it, which at the moment relies on this ID
+ * @see {@link https://graphcms.com/academy/what-is-content-modeling} for more info regarding contextual models
  */
 const pageIDFromCMS = 'cl04asq370z7o0ewwt2726r7t'
 

--- a/graphql/queries/getAboutMePage.ts
+++ b/graphql/queries/getAboutMePage.ts
@@ -7,6 +7,7 @@ const GET_ABOUT_ME_PAGE_QUERY = gql`
   query getAboutMePageSections($id: ID!){
     aboutMePage(where: { id: $id }){
       sections {
+        id
         title
       }
     }

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -75,3 +75,19 @@ export const StackCategoryEnum = {
 } as const
 
 export type StackCategory = keyof typeof StackCategoryEnum;
+
+export type Image = {
+  asset: Asset;
+  mainCaption: string;
+  subCaption: string;
+}
+
+export type Section = {
+  title: string;
+  images: Array<Image>
+  description: string;
+}
+
+export type AboutMePage = {
+  sections: Array<Section>
+}

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -83,6 +83,7 @@ export type Image = {
 }
 
 export type Section = {
+  id: string;
   title: string;
   images: Array<Image>
   description: string;

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -77,9 +77,10 @@ export const StackCategoryEnum = {
 export type StackCategory = keyof typeof StackCategoryEnum;
 
 export type Image = {
+  id: string;
   asset: Asset;
-  mainCaption: string;
   subCaption: string;
+  mainCaption: string;
 }
 
 export type Section = {

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -1,3 +1,5 @@
+import { Element } from '@graphcms/rich-text-types'
+
 export type Stack = {
   id: string;
   language: string;
@@ -83,11 +85,15 @@ export type Image = {
   mainCaption: string;
 }
 
+export type RichText = {
+  raw: Element[];
+}
+
 export type Section = {
   id: string;
   title: string;
   images: Array<Image>
-  description: string;
+  description: RichText;
 }
 
 export type AboutMePage = {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@chakra-ui/react": "^1.1.5",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
+    "@graphcms/rich-text-react-renderer": "^0.4.2",
     "@laurabeatris/chakra-ui-flashless": "^0.2.11",
     "file-loader": "^6.2.0",
     "framer-motion": "^3.2.2-rc.1",
@@ -35,6 +36,7 @@
     "use-sound": "^2.0.1"
   },
   "devDependencies": {
+    "@graphcms/rich-text-types": "^0.3.1",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.14.0",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,11 +1,12 @@
 import { VStack } from '@chakra-ui/react'
 
+import { InferGetStaticPropsType } from 'next'
+
+import { ImageWithCaptions } from 'components/ImageWithCaptions'
+
 import { getAboutMePage } from 'graphql/queries/getAboutMePage'
 
 import { Heading } from 'components/Base/Heading'
-import { HighlightLink } from 'components/Base/HighlightLink'
-import { Paragraph } from 'components/Base/Paragraph'
-import { PlaceImage } from 'components/PlaceImage'
 
 export const getStaticProps = async () => {
   try {
@@ -26,7 +27,9 @@ export const getStaticProps = async () => {
   }
 }
 
-export default function About ({ sections }) {
+export default function About ({
+  sections
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <VStack
       width='full'
@@ -35,7 +38,7 @@ export default function About ({ sections }) {
       paddingBottom={10}
       alignItems='flex-start'
     >
-      {sections.map(({ id, title }) => (
+      {sections.map(({ id, title, images }) => (
         <VStack
           key={id}
           width='full'
@@ -43,6 +46,15 @@ export default function About ({ sections }) {
           alignItems='flex-start'
         >
           <Heading as='h2'>{title}</Heading>
+
+          {images.map(({ id, mainCaption, subCaption, asset }) => (
+            <ImageWithCaptions
+              key={id}
+              imageSrc={asset.url}
+              subCaption={subCaption}
+              mainCaption={mainCaption}
+            />
+          ))}
         </VStack>
       ))}
     </VStack>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -26,7 +26,7 @@ export const getStaticProps = async () => {
   }
 }
 
-export default function About () {
+export default function About ({ sections }) {
   return (
     <VStack
       width='full'
@@ -35,65 +35,16 @@ export default function About () {
       paddingBottom={10}
       alignItems='flex-start'
     >
-      <VStack
-        width='full'
-        spacing={5}
-        alignItems='flex-start'
-      >
-        <Heading as='h2'>About my life 🏝</Heading>
-        <Paragraph variant='regular'>
-          I was born in <HighlightLink href='https://pt.wikipedia.org/wiki/Rio_Grande_(Rio_Grande_do_Sul)'>Rio Grande</HighlightLink>{' '}
-          and have been living in <HighlightLink href='https://pt.wikipedia.org/wiki/Florian%C3%B3polis'>Florianópolis</HighlightLink> for 15 years.
-        </Paragraph>
-
-        <PlaceImage
-          name='Florianópolis'
-          imageSrc='/images/florianopolis.jpg'
-          startYear={2008}
-        />
-
-        <PlaceImage
-          name='Rio Grande'
-          endYear={2008}
-          imageSrc='/images/rio-grande.jpg'
-          startYear={2002}
-        />
-      </VStack>
-
-      <VStack
-        width='full'
-        spacing={5}
-        alignItems='flex-start'
-      >
-        <Heading as='h2'>Hobbies 🎶🎮</Heading>
-        <Paragraph variant='regular'>
-          Since I was a child, I love expressing my feelings with music.
-          I started to play violin when I was 12 years old and I'm currently learning piano. 🎹
-        </Paragraph>
-        <Paragraph variant='regular'>
-          I also love video games because of the possibility of interacting with people from all over the worlds.
-        </Paragraph>
-      </VStack>
-
-      <VStack
-        width='full'
-        spacing={5}
-        alignItems='flex-start'
-      >
-        <Heading as='h2'>Programming Journey 💻</Heading>
-        <Paragraph variant='regular'>
-          When I was in high school, wondering what would be my major,
-          I saw in technology an opportunity to meet people from all over the world and that's why I decided to start studying Python and programming fundamentals even before starting college.
-        </Paragraph>
-        <Paragraph variant='regular'>
-          When I started a Bachelor's Degree in Analysis and Systems Development, I
-          would often get home everyday and put everything that I learned on my GitHub profile, and this helped me land my first job as a Full Stack Developer.
-        </Paragraph>
-        <Paragraph variant='regular'>
-          Since I started to program, I'm a real believer in learning in public and
-          I always try to share the knowledge that I gained throughout my journey with the community.
-        </Paragraph>
-      </VStack>
+      {sections.map(({ id, title }) => (
+        <VStack
+          key={id}
+          width='full'
+          spacing={5}
+          alignItems='flex-start'
+        >
+          <Heading as='h2'>{title}</Heading>
+        </VStack>
+      ))}
     </VStack>
   )
 }

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,12 +1,10 @@
 import { VStack } from '@chakra-ui/react'
-
 import { InferGetStaticPropsType } from 'next'
-
-import { ImageWithCaptions } from 'components/ImageWithCaptions'
-
-import { getAboutMePage } from 'graphql/queries/getAboutMePage'
+import { RichText } from '@graphcms/rich-text-react-renderer'
 
 import { Heading } from 'components/Base/Heading'
+import { ImageWithCaptions } from 'components/ImageWithCaptions'
+import { getAboutMePage } from 'graphql/queries/getAboutMePage'
 
 export const getStaticProps = async () => {
   try {
@@ -38,7 +36,7 @@ export default function About ({
       paddingBottom={10}
       alignItems='flex-start'
     >
-      {sections.map(({ id, title, images }) => (
+      {sections.map(({ id, title, description, images }) => (
         <VStack
           key={id}
           width='full'
@@ -46,6 +44,7 @@ export default function About ({
           alignItems='flex-start'
         >
           <Heading as='h2'>{title}</Heading>
+          <RichText content={description.raw} />
 
           {images.map(({ id, mainCaption, subCaption, asset }) => (
             <ImageWithCaptions

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,9 +1,30 @@
 import { VStack } from '@chakra-ui/react'
 
+import { getAboutMePage } from 'graphql/queries/getAboutMePage'
+
 import { Heading } from 'components/Base/Heading'
 import { HighlightLink } from 'components/Base/HighlightLink'
 import { Paragraph } from 'components/Base/Paragraph'
 import { PlaceImage } from 'components/PlaceImage'
+
+export const getStaticProps = async () => {
+  try {
+    const { sections } = await getAboutMePage()
+
+    return {
+      props: {
+        sections
+      }
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+
+    return {
+      props: {}
+    }
+  }
+}
 
 export default function About () {
   return (

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -5,6 +5,8 @@ import { RichText } from '@graphcms/rich-text-react-renderer'
 import { Heading } from 'components/Base/Heading'
 import { ImageWithCaptions } from 'components/ImageWithCaptions'
 import { getAboutMePage } from 'graphql/queries/getAboutMePage'
+import { Paragraph } from 'components/Base/Paragraph'
+import { HighlightLink } from 'components/Base/HighlightLink'
 
 export const getStaticProps = async () => {
   try {
@@ -23,6 +25,13 @@ export const getStaticProps = async () => {
       props: {}
     }
   }
+}
+
+const RichTextParagraph = ({ children }) => <Paragraph variant='regular'>{children}</Paragraph>
+const RichTextAnchor = ({ children, href }) => <HighlightLink href={href}>{children}</HighlightLink>
+const richTextCustomElements = {
+  p: RichTextParagraph,
+  a: RichTextAnchor
 }
 
 export default function About ({
@@ -44,7 +53,10 @@ export default function About ({
           alignItems='flex-start'
         >
           <Heading as='h2'>{title}</Heading>
-          <RichText content={description.raw} />
+          <RichText
+            content={description.raw}
+            renderers={richTextCustomElements}
+          />
 
           {images.map(({ id, mainCaption, subCaption, asset }) => (
             <ImageWithCaptions

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,6 +826,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphcms/rich-text-react-renderer@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@graphcms/rich-text-react-renderer/-/rich-text-react-renderer-0.4.2.tgz#c8cd757b53c2fbef8b64241ecfa0b2d0955e6bee"
+  integrity sha512-xnqKl0sg4ycySSDLdo1FwHhOMvDmiFwwoQswkOgGvFA74/jvT+p+uwNLuE2KTlmxaBz6dhCCCCU7XEFS/gYo2g==
+  dependencies:
+    "@graphcms/rich-text-types" "^0.3.1"
+    escape-html "^1.0.3"
+
+"@graphcms/rich-text-types@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@graphcms/rich-text-types/-/rich-text-types-0.3.1.tgz#ee8cec326f42e710970f372b9fde2f70e34c5e9c"
+  integrity sha512-BCZ8ZombSXnGy9g83guTgqX9sezEUSijR1HhEaals3N70zZ3futZ0YfPdC7/DGQEH7itAJGf7HT+KjHBCsepPg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@hapi/accept@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.1.tgz#068553e867f0f63225a506ed74e899441af53e10"
@@ -2765,6 +2780,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Relates to #48 

### Summary 
Previously, all the text content from the "About page" was directly managed in the source code, leading to a boring process to change update and manage changes. Now the page is being statically built by fetching content from the CMS.

I created a couple of models in the GraphQL API in order to handle the page sections:

<img width="150" alt="Screenshot 2022-02-27 at 13 26 04" src="https://user-images.githubusercontent.com/48022589/155882245-4fa167a3-e0b0-4836-bb95-dfdb77189804.png"> <img width="150" alt="Screenshot 2022-02-27 at 13 26 23" src="https://user-images.githubusercontent.com/48022589/155882261-a367ddf0-4968-41a2-a1d5-98360dafed6a.png"> <img width="150" alt="Screenshot 2022-02-27 at 13 26 34" src="https://user-images.githubusercontent.com/48022589/155882272-aca880f3-fa52-4b34-adbd-59062235a44c.png">

The `aboutMePage` is a subject model, which means that is managed to serve a specific client purpose, as a structure for the presentation layer - you can read more about different types of content models on [this article from GraphCMS](https://graphcms.com/academy/what-is-content-modeling)

>  The content models that contain all of the structured content that will populate the project, which we at GraphCMS call “Subject Models,” will be the backbone of the content needed for the various presentation layers. 

### Implementation Styles

<img width="300" alt="Screenshot 2022-02-27 at 13 23 02" src="https://user-images.githubusercontent.com/48022589/155882124-9ece533d-2e0b-4718-8515-be0aa3eae225.png">

